### PR TITLE
MA-438: Exit code needed for status when not running

### DIFF
--- a/init.d/passenger-datadog-monitor.sh
+++ b/init.d/passenger-datadog-monitor.sh
@@ -79,11 +79,13 @@ status() {
     PID="$(cat ${PIDFILE})"
     if [[ -z "$(ps axf | grep ${PID} | grep -v grep)" ]]; then
       printf "%s\n" "${PDM} dead but pidfile exists"
+      exit 1
     else
       echo "${PDM} Running"
     fi
   else
     printf "%s\n" "${PDM} not running"
+    exit 3
   fi
 }
 


### PR DESCRIPTION
Turns out chef uses these exit codes to determine status of service when `service foo status` is run.